### PR TITLE
Fix of Rich#getEditorOptions

### DIFF
--- a/lib/rich.rb
+++ b/lib/rich.rb
@@ -57,7 +57,7 @@ module Rich
     editor_options = self.editor.merge(base)
        
     # merge in local overrides
-    editor_options.merge!(overrides)
+    editor_options.merge!(overrides) if overrides
     
     puts editor_options.inspect
     


### PR DESCRIPTION
Hello!

I attentively followed through all gem's setup steps in readme.
Right after adding `:as => :rich` to my text field I began seeing error "can't convert nil into Hash".

Exploration led me to #getEditorOptions method of Rich class. The problem there is that previous function in caller chain passes nil as arg which causes error because default "overrides={}" doesn't work if nil passed.

The simplest demonstration of this:

``` ruby
def a b={};puts b.inspect;end;a(nil) 
=> nil
```

I didn't run into details of gem deep, but it seems that anyway #getEditorOptions method itself should be fixed to reflect this issue. Mine quick hack just points direction.

And one more:

Why not to follow ruby's conventions and name method get_editor_options? Strange to see javascript's notation in .rb files.

Thanks, hope this makes sense.
