### PR TITLE
added a paperclip_options hash to pass in options (like s3 storage) from the init file.

### DIFF
--- a/lib/rich.rb
+++ b/lib/rich.rb
@@ -45,6 +45,15 @@ module Rich
   mattr_accessor :allowed_document_types
   @@allowed_document_types = :all
   
+  mattr_accessor :file_storage
+  @@file_storage
+  
+  mattr_accessor :s3_credentials
+  @@s3_credentials
+  
+  mattr_accessor :file_path
+  @@file_path
+  
   # Configuration defaults (these map directly to ckeditor settings)
   mattr_accessor :editor
   @@editor = {


### PR DESCRIPTION
I'm using this to store uploaded files on s3, but if the hash isn't set in the init file, it works the same as the current master version.
