### PR TITLE
typo was causing a compilation error when using with RailsAdmin.

### DIFF
--- a/vendor/assets/ckeditor/ckeditor-contrib/skins/BootstrapCK/editor.css
+++ b/vendor/assets/ckeditor/ckeditor-contrib/skins/BootstrapCK/editor.css
@@ -508,8 +508,8 @@ padding-bottom:0;
 }
 .cke_skin_BootstrapCK-Skin .cke_contextmenu{
 padding:2px;
-}.
-cke_skin_BootstrapCK-Skin .cke_menuitem a{
+}
+.cke_skin_BootstrapCK-Skin .cke_menuitem a{
 display:block;
 }
 .cke_skin_BootstrapCK-Skin .cke_menuitem span{


### PR DESCRIPTION
The period followed by a linebreak may be a SCSS-ism I'm not aware of, but it was throwing a compilation error with Rails 3.2.3 and edge Rails Admin.

http://cl.ly/2J3X1K1N2i1O3I0U221T
