### PR TITLE
Fix id issue for Formtastic

### DIFF
--- a/app/inputs/rich_picker_input.rb
+++ b/app/inputs/rich_picker_input.rb
@@ -19,7 +19,7 @@ if (Object.const_defined?("Formtastic") && Gem.loaded_specs["formtastic"].versio
           begin
             rich_file = Rich::RichFile.find(rich_file_id)
             img_path = rich_file.rich_file 
-          rescue Activerecord::RecordNotFound
+          rescue ActiveRecord::RecordNotFound
             img_path = editor_options[:placeholder_image]
           end
 


### PR DESCRIPTION
I switched from using the scope_id to calling the method on the object to get the current ID. If the ID is nil or the Rich::RichFile record doesn't exist, an ActiveRecord::RecordNotFound exception is raised. If an exception is raised, we use the placeholder_image
