### PR TITLE
Fix issue with missing dom_id param

### DIFF
--- a/app/assets/javascripts/rich/browser/filebrowser.js
+++ b/app/assets/javascripts/rich/browser/filebrowser.js
@@ -36,9 +36,10 @@ rich.Browser.prototype = {
 		browser.selectStyle(def);
 
     //check if we are inserting an object
-    var split_field_name = $.QueryString["dom_id"].split('_');
+    var dom_id_param = $.QueryString["dom_id"];
+    var split_field_name = dom_id_param ? dom_id_param.split('_') : null;
 
-		if(opt.length < 2 || split_field_name[split_field_name.length - 1] == "id") {
+		if(opt.length < 2 || (split_field_name && split_field_name[split_field_name.length - 1] == "id")) {
 			$('#styles').hide();
 			browser.selectStyle(opt[0]);
 		}


### PR DESCRIPTION
When the `dom_id` query param was missing in the file browser params, a JavaScript error occurred because `split("_")` was called on a null object. I have not investigated this in depth, but it could be due to a recent change to jQuery. The version used in my test was _1.8.2_
