### PR TITLE
Fix for embedding video with multiple instances

### DIFF
--- a/vendor/assets/ckeditor/ckeditor-contrib/plugins/MediaEmbed/plugin.js
+++ b/vendor/assets/ckeditor/ckeditor-contrib/plugins/MediaEmbed/plugin.js
@@ -57,7 +57,7 @@
             {
                 label: 'Embed Media',
                 command: 'MediaEmbed',
-                icon: this.path + 'images/icon.png'
+                icon: this.path + 'images/icon.png',
                 toolbar: 'mediaembed'
             } );
         }


### PR DESCRIPTION
Applying a fix from the original MediaEmbed plugin regarding multiple instances on one page

https://github.com/frozeman/MediaEmbed/commit/e6c8da17dc6a8962cf504ede3846e767ca6cf07a
