### PR TITLE
Rename html_default_value to form_default_value

### DIFF
--- a/app/views/rails_admin/main/_form_rich_text.html.haml
+++ b/app/views/rails_admin/main/_form_rich_text.html.haml
@@ -1,4 +1,4 @@
-= form.send 'text_area', field.method_name, field.html_attributes.reverse_merge((hdv = field.html_default_value).nil? ? {} : { :value => hdv })
+= form.send 'text_area', field.method_name, field.html_attributes.reverse_merge((hdv = field.form_default_value).nil? ? {} : { :value => hdv })
 
 /= javascript_include_tag "rich/base.js"
 :javascript


### PR DESCRIPTION
It appears that html_default_value has been renamed to form_default_value in rails_admin's master branch, so this pull request simply updates that.
