### PR TITLE
Add Font-Awesome support

### DIFF
--- a/app/assets/javascripts/rich/editor/rich_editor.js.erb
+++ b/app/assets/javascripts/rich/editor/rich_editor.js.erb
@@ -8,3 +8,7 @@ function addQueryString( url, params ) {
 	}
 	return url + ( ( url.indexOf( "?" ) != -1 ) ? "&" : "?" ) + queryString.join( "&" );
 }
+
+// Don't remove empty <i> tags so FontAwesome and similar icon fonts
+// can be used in the editor without magically being stripped out
+delete CKEDITOR.dtd.$removeEmpty['i'];


### PR DESCRIPTION
CKEditor strips out `<i>` tags when you go from source view to preview, which means you cannot add Font-Awesome icons from within the editor without adding a `&nbsp` inside, which is problematic since the space is rendered. This pull request removes `<i>` from the list of nodes in the DTD that are marked for removal if empty, which allows `<i>` tags to remain.

It would be nice to add support for configuring DTD options in the initializer, but since you must delete an item (rather than set it's value to 0 or false) to turn it "off" things get a bit tricky, and that's a whole other can of worms that I didn't feel like getting into at the moment.
