### PR TITLE
Provide compatibility with old and new RailsAdmin for html_default_value/form_default_value

### DIFF
--- a/lib/rich/rails_admin/config/fields/types/rich_editor.rb
+++ b/lib/rich/rails_admin/config/fields/types/rich_editor.rb
@@ -21,6 +21,12 @@ module RailsAdmin::Config::Fields::Types
       end
     end
 
+    # Compatibility with RailsAdmin 0.6.0 AND prior versions
+    # https://github.com/sferik/rails_admin/commit/494205b3a0e128bfc98084ac59b5ee378d3218a1
+    def form_default_value
+      self.respond_to?(:html_default_value) ? html_default_value : super
+    end
+
     def scope_id
       bindings[:object].id
     end


### PR DESCRIPTION
Recent changes created compatibility with new RailsAdmin but broke it with old RailsAdmin. New RailsAdmin does not work with Rails 3.x, so some of us can't upgrade. This simple fix _should_ restore functionality. 

I have tested it with old RailsAdmin (0.4.x), but someone should test it with new RailsAdmin just to be sure.
