### PR TITLE
Updates scope syntax to avoid deprecation warnings in Rails 4.

### DIFF
--- a/app/models/rich/rich_file.rb
+++ b/app/models/rich/rich_file.rb
@@ -5,8 +5,8 @@ require 'kaminari'
 module Rich
   class RichFile < ActiveRecord::Base
 
-    scope :images, where("rich_rich_files.simplified_type = 'image'")
-    scope :files, where("rich_rich_files.simplified_type = 'file'")
+    scope :images,  lambda { where("rich_rich_files.simplified_type = 'image'") }
+    scope :files,   lambda { where("rich_rich_files.simplified_type = 'file'") }
 
     paginates_per Rich.options[:paginates_per]
   end


### PR DESCRIPTION
Was getting deprecation warnings on a Rails 4 project because of scope syntax used. This update removes those.

Example deprecation warning:

```
DEPRECATION WARNING: Using #scope without passing a callable object is deprecated. For example `scope :red, where(color: 'red')` should be changed to `scope :red, -> { where(color: 'red') }`. There are numerous gotchas in the former usage and it makes the implementation more complicated and buggy. (If you prefer, you can just define a class method named `self.red`.). (called from <class:RichFile> at /my_user/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/rich-1ab79e111a4c/app/models/rich/rich_file.rb:8)
```
