### PR TITLE
Added to bypass Paperclip content validation, as Rich already does this

### DIFF
--- a/lib/rich/backends/paperclip.rb
+++ b/lib/rich/backends/paperclip.rb
@@ -10,6 +10,7 @@ module Rich
           :styles => Proc.new {|a| a.instance.set_styles },
           :convert_options => Proc.new { |a| Rich.convert_options[a] }
 
+        do_not_validate_attachment_file_type :rich_file
         validates_attachment_presence :rich_file
         validate :check_content_type
         validates_attachment_size :rich_file, :less_than=>15.megabyte, :message => "must be smaller than 15MB"


### PR DESCRIPTION
The version of Paperclip requires explicit content type validation (https://github.com/thoughtbot/paperclip#security-validations).

Rich already does this to a point, so I've opted to disable the Paperclip requirement.

It may be better at a future date to incorporate the Paperclip validation as it appears to do checks for malicious scripts.
