### PR TITLE
fix rich picker for paperclip 4

### DIFF
--- a/app/inputs/rich_picker_input.rb
+++ b/app/inputs/rich_picker_input.rb
@@ -38,7 +38,7 @@ private
         return editor_options[:placeholder_image] if editor_options[:type].to_s == 'file'
         return editor_options[:placeholder_image] unless method_value.present?
 
-        column_type = column_for(method).type
+        column_type = column_for(method) ? column_for(method).type : :string
         if column_type == :integer
           file = Rich::RichFile.find(method_value)
           file.rich_file.url(:rich_thumb) #we ask paperclip directly for the file, so asset paths should not be an issue

--- a/app/models/rich/rich_file.rb
+++ b/app/models/rich/rich_file.rb
@@ -7,25 +7,25 @@ module Rich
 
     scope :images, where("rich_rich_files.simplified_type = 'image'")
     scope :files, where("rich_rich_files.simplified_type = 'file'")
-    
+
     paginates_per 34
-    
+
     has_attached_file :rich_file,
                       :styles => Proc.new {|a| a.instance.set_styles },
                       :convert_options => Proc.new { |a| Rich.convert_options[a] }
-    
+    do_not_validate_attachment_file_type :rich_file
     validates_attachment_presence :rich_file
     validate :check_content_type
     validates_attachment_size :rich_file, :less_than=>15.megabyte, :message => "must be smaller than 15MB"
-    
+
     before_create :clean_file_name
 
     after_create :cache_style_uris_and_save
     before_update :cache_style_uris
 
 
-    
-    
+
+
     def set_styles
       if self.simplified_type=="image"
         Rich.image_styles
@@ -33,47 +33,47 @@ module Rich
         {}
       end
     end
-    
+
     private
-    
+
     def cache_style_uris_and_save
       cache_style_uris
       self.save!
     end
-    
+
     def cache_style_uris
       uris = {}
-      
+
       rich_file.styles.each do |style|
         uris[style[0]] = rich_file.url(style[0].to_sym, false)
       end
-      
+
       # manualy add the original size
       uris["original"] = rich_file.url(:original, false)
-      
+
       self.uri_cache = uris.to_json
     end
-    
-    def clean_file_name      
+
+    def clean_file_name
       extension = File.extname(rich_file_file_name).gsub(/^\.+/, '')
       filename = rich_file_file_name.gsub(/\.#{extension}$/, '')
-      
+
       filename = CGI::unescape(filename)
       filename = CGI::unescape(filename)
-      
+
       extension = extension.downcase
       filename = filename.downcase.gsub(/[^a-z0-9]+/i, '-')
-      
+
       self.rich_file.instance_write(:file_name, "#{filename}.#{extension}")
     end
-    
+
     def check_content_type
       self.rich_file.instance_write(:content_type, MIME::Types.type_for(rich_file_file_name)[0].content_type)
-      
+
       unless Rich.validate_mime_type(self.rich_file_content_type, self.simplified_type)
         self.errors[:base] << "'#{self.rich_file_file_name}' is not the right type."
       end
     end
-    
+
   end
 end


### PR DESCRIPTION
Paper clip 4 requires that attachements are validated. I added do_not_validate_attachment_file_type :rich_file to take care of this. Also some calls to this column_for(method) came back nil so I defaulted to string.
