### PR TITLE
Attempt to fix "uninitialized constant Rich::RichFile" for Carrierwave

### DIFF
--- a/app/controllers/rich/files_controller.rb
+++ b/app/controllers/rich/files_controller.rb
@@ -59,7 +59,7 @@ module Rich
       file_params = params[:file] || params[:qqfile]
       if(file_params)
         file_params.content_type = Mime::Type.lookup_by_extension(file_params.original_filename.split('.').last.to_sym)
-        @file.rich_file_file_name = file_params
+        @file.rich_file = file_params
       end
 
       if @file.save

--- a/lib/rich/backends/carrierwave.rb
+++ b/lib/rich/backends/carrierwave.rb
@@ -23,11 +23,11 @@ module Rich
       end
   
       def rich_file
-        rich_file_file_name
+        self.rich_file_file_name
       end
 
       def rich_file=(val)
-        rich_file_file_name = val
+        self.rich_file_file_name = val
       end
   
       def uri_cache


### PR DESCRIPTION
Referencing module wasnt enough for me, i was still getting undefined method 'rich_file='. For unknown reasons alias_method wasnt working for me.
Rails 4.0.3, Ruby 2.1.1.
