### PR TITLE
fix for carrierwave

### DIFF
--- a/app/models/rich/rich_file.rb
+++ b/app/models/rich/rich_file.rb
@@ -13,7 +13,9 @@ module Rich
     has_attached_file :rich_file,
                       :styles => Proc.new {|a| a.instance.set_styles },
                       :convert_options => Proc.new { |a| Rich.convert_options[a] }
-    do_not_validate_attachment_file_type :rich_file
+    if self.respond_to?(:do_not_validate_attachment_file_type)
+      do_not_validate_attachment_file_type :rich_file
+    end
     validates_attachment_presence :rich_file
     validate :check_content_type
     validates_attachment_size :rich_file, :less_than=>15.megabyte, :message => "must be smaller than 15MB"


### PR DESCRIPTION
CarrierWave doesn't have 'do_not_validate_attachment_file_type' method.

rails s
=> Booting Thin
=> Rails 4.0.3 application starting in development on http://0.0.0.0:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
Exiting
/Users/marcinadamczyk/.rvm/gems/ruby-2.1.1@selena/gems/activerecord-4.0.3/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method`do_not_validate_attachment_file_type' for Rich::RichFile(no database connection):Class (NoMethodError)
