### PR TITLE
Fix undefined method `rich_file'

### DIFF
--- a/lib/rich/backends/paperclip.rb
+++ b/lib/rich/backends/paperclip.rb
@@ -75,5 +75,5 @@ module Rich
     end
   end
 
-  RichFile.send(:include, Backends::Paperclip)
+  Rich::RichFile.send(:include, Backends::Paperclip)
 end


### PR DESCRIPTION
Fix undefined method `rich_file' for Rich::RichFile using Paperclip.

Minimal version of pull request #145. Was enough for me to fix the problem.