### PR TITLE
Made window scrollable in IE11

### DIFF
--- a/app/assets/javascripts/rich/editor/rich_picker.js
+++ b/app/assets/javascripts/rich/editor/rich_picker.js
@@ -23,7 +23,7 @@ rich.AssetPicker.prototype = {
 		}
 		params.dom_id = dom_id;
 		var url = addQueryString(options.richBrowserUrl, params );
-		window.open(url, 'filebrowser', "width=860,height=500")
+		window.open(url, 'filebrowser', "resizable=yes,scrollbars=yes,width=860,height=500")
   },
 
 	setAsset: function(dom_id, asset, id, type){


### PR DESCRIPTION
Without explicitly setting 'scrollbars' to 'yes', large lists won't scroll in IE11.