### PR TITLE
Fixed Rich picker for for IE, in terms of scrolling and resizing

### DIFF
--- a/app/assets/javascripts/rich/editor/rich_picker.js
+++ b/app/assets/javascripts/rich/editor/rich_picker.js
@@ -2,11 +2,11 @@
 
 var rich = rich || {};
 rich.AssetPicker = function(){
-	
+
 };
 
 rich.AssetPicker.prototype = {
-	
+
 	showFinder: function(dom_id, options){
 		// open a popup
 		var params = {};
@@ -23,7 +23,7 @@ rich.AssetPicker.prototype = {
 		}
 		params.dom_id = dom_id;
 		var url = addQueryString(options.richBrowserUrl, params );
-		window.open(url, 'filebrowser', "width=860,height=500")
+		window.open(url, 'filebrowser', "resizable=yes,scrollbars=yes,width=860,height=500");
   },
 
 	setAsset: function(dom_id, asset, id, type){


### PR DESCRIPTION
Tested on IE 10. Picker window will not scroll, unless 'scrollbars' is set to yes. Likewise for 'resizable'.