### PR TITLE
make assets:precompile recognise various digest sizes

### DIFF
--- a/lib/tasks/rich_tasks.rake
+++ b/lib/tasks/rich_tasks.rake
@@ -2,22 +2,24 @@ require 'fileutils'
 
 desc "Create nondigest versions of all ckeditor digest assets"
 task "assets:precompile" do
-  fingerprint = /\-[0-9a-f]{32}\./
-  for file in Dir["public/assets/ckeditor/**/*"]
-    next unless file =~ fingerprint
-    nondigest = file.sub fingerprint, '.'
-    FileUtils.cp file, nondigest, verbose: true
+  %w(16, 20, 32, 48, 64).each do |length|
+    fingerprint = /\-[0-9a-f]{#{length}}\./
+    for file in Dir["public/assets/ckeditor/**/*"]
+      next unless file =~ fingerprint
+      nondigest = file.sub fingerprint, '.'
+      FileUtils.cp file, nondigest, verbose: true
+    end
   end
 end
 
 namespace :rich do
-      
+
   desc "Re-generate image styles"
   task :refresh_assets => :environment do
     # re-generate images
     ENV['CLASS'] = "Rich::RichFile"
     Rake::Task["paperclip:refresh"].invoke
-    
+
     # re-generate uri cache
     Rich::RichFile.find_each(&:save)
   end


### PR DESCRIPTION
32 bytes is not the only possible length of the digests, other lengths are also supported. See
https://github.com/rails/sprockets/blob/master/lib/sprockets/digest_utils.rb for more info.

In my case I had problems with rich in production mode because the `assets:precompile` task was not compatible my 64 characters digests.