### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -123,7 +123,7 @@ This is the file manager.
 
 == Rich in production mode
 
-Rich works just fine in production mode. To accomodate the structure of the CKEditor source, Rich extends the <tt>assets:precompile</tt> task to make sure the full CKEditor source tree is copied to your assets folder. So the following works as you would expect:
+Rich works just fine in production mode. To accommodate the structure of the CKEditor source, Rich extends the <tt>assets:precompile</tt> task to make sure the full CKEditor source tree is copied to your assets folder. So the following works as you would expect:
 
   rake assets:precompile
 


### PR DESCRIPTION
kreativgebiet, I've corrected a typographical error in the documentation of the [rich](https://github.com/kreativgebiet/rich) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.