### PR TITLE
Fix rich rake task assets:precompile, to store non digest versions of…

### DIFF
--- a/lib/tasks/rich_tasks.rake
+++ b/lib/tasks/rich_tasks.rake
@@ -2,7 +2,7 @@ require 'fileutils'
 
 desc "Create nondigest versions of all ckeditor digest assets"
 task "assets:precompile" do
-  fingerprint = /\-[0-9a-f]{32}\./
+  fingerprint = /\-[0-9a-f]{32}\.|\-[0-9a-f]{64}\./
   for file in Dir["public/assets/ckeditor/**/*"]
     next unless file =~ fingerprint
     nondigest = file.sub fingerprint, '.'


### PR DESCRIPTION
… assets. Because of sprockets version 3 use fingerprints with 64 chars length