### PR TITLE
Update rich_picker.rb

### DIFF
--- a/lib/rich/rails_admin/config/fields/types/rich_picker.rb
+++ b/lib/rich/rails_admin/config/fields/types/rich_picker.rb
@@ -28,8 +28,13 @@ module RailsAdmin::Config::Fields::Types
       if value.to_s.html_safe != ""
         if (true if Float(value) rescue false)
           # if the value is numeric we assume its an object id
-          rich_file = Rich::RichFile.find(value)
-          rich_file.rich_file.url(:rich_thumb)
+          # Check if the id exist otherwise show placeholder image
+          if Rich::RichFile.exists?(value)
+            rich_file = Rich::RichFile.find(value)
+            rich_file.rich_file.url(:rich_thumb)
+          else
+            editor_options[:placeholder_image]
+          end
         else
           # if not, we assume its a url
           value.to_s


### PR DESCRIPTION
Added check if file id exists.

If I were to put a manual number in the image field this would result in this error:

ActiveRecord::RecordNotFound (Couldn't find Rich::RichFile with 'id'=45):
  activerecord (4.2.4) lib/active_record/core.rb:155:in `find'
  /var/www/rmf/shared/bundle/ruby/2.2.0/bundler/gems/rich-85c32d029d36/lib/rich/rails_admin/config/fields/types/rich_picker.rb:31:in `preview_image_path'
  /var/www/rmf/shared/bundle/ruby/2.2.0/bundler/gems/rich-85c32d029d36/app/views/rails_admin/main/_form_rich_picker.html.haml:5:in `__var_www_rmf_shared_bundle_ruby_______bundler_gems_rich___c__d___d___app_views_rails_admin_main__form_rich_picker_html_haml__2223171856044628067_69995085617900'