### PR TITLE
Prevent calling fetch on empty config option

### DIFF
--- a/app/inputs/rich_input.rb
+++ b/app/inputs/rich_input.rb
@@ -7,8 +7,8 @@ if (Object.const_defined?("Formtastic") && Gem.loaded_specs["formtastic"].versio
       scope_id = object.id
       editor_options = Rich.options(
                                     options[:config], 
-                                    options[:config].fetch(:scope_type, scope_type),
-                                    options[:config].fetch(:scope_id, scope_id)
+                                    options[:config].try(:fetch, :scope_type, scope_type),
+                                    options[:config].try(:fetch, :scope_id, scope_id)
                                   )
 
       input_wrapping do


### PR DESCRIPTION
This prevents a potential `undefined method 'fetch' for nil:NilClass` if the caller doesn't provide a config option. It shouldn't be required to pass `config: {}` everywhere you use the rich input if you are fine with the defaults.
