### PR TITLE
Rmagick support for Carrierwave backend

### DIFF
--- a/lib/rich.rb
+++ b/lib/rich.rb
@@ -194,7 +194,7 @@ module Rich
 
     if self.backend == :paperclip
       require 'rich/backends/paperclip'
-    elsif self.backend == :carrierwave
+    elsif self.backend == :carrierwave || self.backend == :carrierwave_rmagick
       require 'rich/backends/carrierwave'
     end
   end

--- a/lib/rich/backends/rich_file_uploader.rb
+++ b/lib/rich/backends/rich_file_uploader.rb
@@ -3,8 +3,11 @@
 class RichFileUploader < CarrierWave::Uploader::Base
 
   # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
-  include CarrierWave::MiniMagick
+  if Rich.backend == :carrierwave
+    include CarrierWave::MiniMagick
+  elsif Rich.backend == :carrierwave_rmagick
+    include CarrierWave::RMagick
+  end
 
   # Choose what kind of storage to use for this uploader:
   # storage :file

--- a/lib/rich/engine.rb
+++ b/lib/rich/engine.rb
@@ -14,7 +14,7 @@ module Rich
               ckeditor/*.html
               ckeditor/*.md
       )
-      app.middleware.use 'Rack::RawUpload', :paths => ['/rich/files']
+      app.middleware.use Rack::RawUpload, :paths => ['/rich/files']
     end
 
     initializer 'rich.include_authorization' do |app|


### PR DESCRIPTION
- Add :carrierwave_rmagick backend type that forces Carrierwave uploader to use RMagic instead of MiniMagic. It is required if target app uses RMagic for its own uploaders and developers do not want to depend on both "mini_magick" and "rmagick" gems.
- Fixed deprecation warning from middleware builder.