### PR TITLE
Fix crash when using rails >= 5.1

### DIFF
--- a/lib/rich/engine.rb
+++ b/lib/rich/engine.rb
@@ -14,7 +14,7 @@ module Rich
               ckeditor/*.html
               ckeditor/*.md
       )
-      app.middleware.use 'Rack::RawUpload', :paths => ['/rich/files']
+      app.middleware.use Rack::RawUpload, :paths => ['/rich/files']
     end
 
     initializer 'rich.include_authorization' do |app|


### PR DESCRIPTION
Was getting the following deprecation warning in Rails 5.0:

```
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "Rack::RawUpload" => Rack::RawUpload
```

In Rails 5.1 this usage has been deprecated and causes the app to crash on boot.

This small patch fixes that.